### PR TITLE
Move searchbar to the top of the page

### DIFF
--- a/docs/assets/_custom.scss
+++ b/docs/assets/_custom.scss
@@ -45,7 +45,6 @@ li.navigation-icon-pad {
 
 #book-search-results {
   position: absolute;
-  top: 110px;
 }
 
 ul#book-search-results {
@@ -53,7 +52,7 @@ ul#book-search-results {
   margin: 0;
   list-style-type: none;
   float: left;
-  width: 30em;
+  width: 100%;
   max-height: 700px;
   overflow-y: scroll;
   border-radius: 6px;

--- a/docs/assets/search.js
+++ b/docs/assets/search.js
@@ -93,7 +93,7 @@
     const searchHits = window.pages.filter(page => page.content.toLowerCase().includes(input.value.toLowerCase()) )
     searchHits.forEach(function (page) {
 
-      var contentPreview = getSearchPreview(page, input.value, 30);
+      var contentPreview = getSearchPreview(page, input.value, 50);
 
       const li = element('<li><p></p><small></small></li>');
       const p = li.querySelector('p'), small = li.querySelector('small');

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.Language.Lang }}" dir="{{ .Site.Language.LanguageDirection | default "ltr" }}">
+<head>
+  {{ partial "docs/html-head" . }}
+  {{ partial "docs/inject/head" . }}
+</head>
+<body dir="{{ .Site.Language.LanguageDirection | default "ltr" }}">
+  <input type="checkbox" class="hidden toggle" id="menu-control" />
+  <input type="checkbox" class="hidden toggle" id="toc-control" />
+  <main class="container flex">
+    <aside class="book-menu">
+      <div class="book-menu-content">
+        {{ template "menu" . }} <!-- Left menu Content -->
+      </div>
+    </aside>
+
+    <div class="book-page">
+      <header class="book-header">
+        {{ template "header" . }} <!-- Mobile layout header -->
+      </header>
+
+      {{ partial "docs/inject/content-before" . }}
+      {{ template "main" . }} <!-- Page Content -->
+      {{ partial "docs/inject/content-after" . }}
+
+      <footer class="book-footer">
+        {{ template "footer" . }} <!-- Footer under page content -->
+        {{ partial "docs/inject/footer" . }}
+      </footer>
+
+      {{ template "comments" . }} <!-- Comments block -->
+
+      <label for="menu-control" class="hidden book-menu-overlay"></label>
+    </div>
+
+    {{ if default true (default .Site.Params.BookToC .Params.BookToC) }}
+    <aside class="book-toc">
+      <div class="book-toc-content">
+        {{ template "toc" . }} <!-- Table of Contents -->
+      </div>
+    </aside>
+    {{ end }}
+  </main>
+
+  {{ partial "docs/inject/body" . }}
+</body>
+</html>
+
+{{ define "menu" }}
+  {{ partial "docs/menu" . }}
+{{ end }}
+
+{{ define "header" }}
+  {{ partial "docs/header" . }}
+
+  {{ if default true (default .Site.Params.BookToC .Params.BookToC) }}
+  <aside class="hidden clearfix">
+    {{ template "toc" . }}
+  </aside>
+  {{ end }}
+{{ end }}
+
+{{ define "footer" }}
+  {{ partial "docs/footer" . }}
+{{ end }}
+
+{{ define "comments" }}
+  {{ if and .Content (default true (default .Site.Params.BookComments .Params.BookComments)) }}
+  <div class="book-comments">
+    {{- partial "docs/comments" . -}}
+  </div>
+  {{ end }}
+{{ end }}
+
+{{ define "main" }}
+  <article class="markdown">
+    {{- .Content -}}
+  </article>
+{{ end }}
+
+{{ define "toc" }}
+  {{ partial "docs/toc" . }}
+{{ end }}

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -15,6 +15,16 @@
     </aside>
 
     <div class="book-page">
+      <div class="book-search">
+        <input type="text" id="book-search-input" placeholder="{{ i18n "Search" }}" aria-label="{{ i18n "Search" }}" maxlength="64" data-hotkeys="s/" />
+      </div>
+      <div >
+        <ul id="book-search-results">
+          <!--Reserve a <li> to solve safari compatibility problem-->
+          <li id="liFirst" style="background-color:#e7e8eb00; border-bottom:#e7e8eb00; color:#e7e8eb00;">.</li>
+        </ul>
+      </div>
+      </br>
       <header class="book-header">
         {{ template "header" . }} <!-- Mobile layout header -->
       </header>

--- a/docs/layouts/partials/docs/search.html
+++ b/docs/layouts/partials/docs/search.html
@@ -1,6 +1,5 @@
 {{ if default true .Site.Params.BookSearch }}
 <div class="book-search">
-  <input type="text" id="book-search-input" placeholder="{{ i18n "Search" }}" aria-label="{{ i18n "Search" }}" maxlength="64" data-hotkeys="s/" />
   <div class="book-search-spinner hidden"></div>
   <a href="https://github.com/apache/iceberg" target="_blank">
     <img src="{{ .Site.BaseURL }}/img/GitHub-Mark.png" target="_blank" class="top-external-icon"/>

--- a/docs/themes/hugo-book/layouts/_default/baseof.html
+++ b/docs/themes/hugo-book/layouts/_default/baseof.html
@@ -15,13 +15,6 @@
     </aside>
 
     <div class="book-page">
-      <div >
-        <ul id="book-search-results">
-          <!--Reserve a <li> to solve safari compatibility problem-->
-          <li id="liFirst" style="background-color:#e7e8eb00; border-bottom:#e7e8eb00; color:#e7e8eb00;">.</li>
-        </ul>
-      </div>
-      </br>
       <header class="book-header">
         {{ template "header" . }} <!-- Mobile layout header -->
       </header>


### PR DESCRIPTION
This moves the searchbar off the left nav and to the top of the page. This allows the searchbar to remain static as the left nav-bar collapses.